### PR TITLE
docs: replace the future reference link with automation

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -3,7 +3,7 @@ import { Manifest } from "deno-slack-sdk/mod.ts";
 /**
  * The app manifest contains the app's configuration. This
  * file defines attributes like app name and description.
- * https://api.slack.com/future/manifest
+ * https://api.slack.com/automation/manifest
  */
 export default Manifest({
   name: "deno-blank-template",


### PR DESCRIPTION
### Type of change

- [x] Documentation

### Summary

This PR makes the redirect to `automation` happen before clicking the link.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
