### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,7 +30,7 @@
     "test": "deno fmt --check && deno lint && deno test --permit-no-files --allow-read"
   },
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/"
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,6 +31,6 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1"
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2"
   }
 }

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 
 /**
  * The app manifest contains the app's configuration. This


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)